### PR TITLE
Testing correcting CircleCI Python 3.12.1

### DIFF
--- a/shoebae/.circleci/config.yml
+++ b/shoebae/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     working_directory: ~/circleci-python
     docker:
-      - image: "circleci/python:3.6.4"
+      - image: "circleci/python:3.12.1"
     steps:
       - checkout
       - run:
@@ -16,7 +16,7 @@ jobs:
   test:
     working_directory: ~/circleci-python
     docker:
-      - image: "circleci/python:3.6.4"
+      - image: "circleci/python:3.12.1"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Project runs on Python 3.12.1, but our CircleCI was set to Python 3.6; testing to see if I can use 3.12.1 with it.